### PR TITLE
モバイル版Safariでのトップページのナビゲーション非表示バグを修正

### DIFF
--- a/src/btz-2022/btz-common.css
+++ b/src/btz-2022/btz-common.css
@@ -40,10 +40,6 @@ body {
   body {
     height: calc(100dvh - 2rem);
   }
-
-  model-viewer {
-    height: 100dvh;
-  }
 }
 
 header {

--- a/src/btz-2022/index.css
+++ b/src/btz-2022/index.css
@@ -8,12 +8,6 @@ body {
   visibility: hidden; /*アニメーション表示前に要素を隠す */
 }
 
-@supports (min-height: 100dvh) {
-  model-viewer {
-    height: 100dvh;
-  }
-}
-
 model-viewer {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## 🎲 Issue 番号

- Close #35

## ✍️ 概要
モバイル版Safariでトップページを表示した際に、ナビゲーションが表示されないバグを修正しました。